### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/clock
+ * @see https://github.com/ergebnis/clock
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2018 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/clock
+@see https://github.com/ergebnis/clock
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.0.0...master`][1.0.0...master].
+For a full diff see [`2.0.0...master`][2.0.0...master].
+
+## [`2.0.0`][2.0.0]
+
+For a full diff see [`1.0.0...2.0.0`][1.0.0...2.0.0].
+
+### Changed
+
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#52]), by [@localheinz]
+
+  Run
+
+  ```
+  $ composer remove localheinz/clock
+  ```
+
+  and
+
+  ```
+  $ composer require ergebnis/clock
+  ```
+
+  to update.
+
+  Run
+
+  ```
+  $ find . -type f -exec sed -i '.bak' 's/Localheinz\\Clock/Ergebnis\\Clock/g' {} \;
+  ```
+
+  to replace occurrences of `Localheinz\Clock` with `Ergebnis\Clock`.
+
+  Run
+
+  ```
+  $ find -type f -name '*.bak' -delete
+  ```
+
+  to delete backup files created in the previous step.
 
 ### Fixed
 
@@ -21,13 +59,17 @@ For a full diff see [`36912f6...1.0.0`][36912f6...1.0.0].
 * Added `SystemClock` ([#1]), by @localheinz
 * Added `FrozenClock` ([#2]), by @localheinz
 
-[1.0.0]: https://github.com/localheinz/clock/releases/tag/1.0.0
+[1.0.0]: https://github.com/ergebnis/clock/releases/tag/1.0.0
+[2.0.0]: https://github.com/ergebnis/clock/releases/tag/2.0.0
 
-[36912f6...1.0.0]: https://github.com/localheinz/clock/compare/36912f6...1.0.0
-[1.0.0...master]: https://github.com/localheinz/clock/compare/1.0.0...master
+[36912f6...1.0.0]: https://github.com/ergebnis/clock/compare/36912f6...1.0.0
+[1.0.0...2.0.0]: https://github.com/ergebnis/clock/compare/1.0.0...2.0.0
+[2.0.0...master]: https://github.com/ergebnis/clock/compare/2.0.0...master
 
-[#1]: https://github.com/localheinz/clock/pull/1
-[#2]: https://github.com/localheinz/clock/pull/2
-[#41]: https://github.com/localheinz/clock/pull/41
+[#1]: https://github.com/ergebnis/clock/pull/1
+[#2]: https://github.com/ergebnis/clock/pull/2
+[#41]: https://github.com/ergebnis/clock/pull/41
+[#52]: https://github.com/ergebnis/clock/pull/52
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # clock
 
-[![Continuous Integration](https://github.com/localheinz/clock/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/clock/actions)
-[![Code Coverage](https://codecov.io/gh/localheinz/clock/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/clock)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/clock/v/stable)](https://packagist.org/packages/localheinz/clock)
-[![Total Downloads](https://poser.pugx.org/localheinz/clock/downloads)](https://packagist.org/packages/localheinz/clock)
+[![Continuous Integration](https://github.com/ergebnis/clock/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/clock/actions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/clock/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/clock)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/clock/v/stable)](https://packagist.org/packages/ergebnis/clock)
+[![Total Downloads](https://poser.pugx.org/ergebnis/clock/downloads)](https://packagist.org/packages/ergebnis/clock)
 
 Provides a simple abstraction of a clock, following the suggestion by [Martin Fowler](https://martinfowler.com/bliki/ClockWrapper.html).
 
@@ -12,7 +12,7 @@ Provides a simple abstraction of a clock, following the suggestion by [Martin Fo
 Run
 
 ```
-$ composer require localheinz/clock
+$ composer require ergebnis/clock
 ```
 
 ## Usage
@@ -22,7 +22,9 @@ $ composer require localheinz/clock
 Create a new system clock and use it to determine the current time:
 
 ```php
-use Localheinz\Clock;
+<?php
+
+use Ergebnis\Clock;
 
 $timeZone = new \DateTimeZone('Europe/Berlin');
 
@@ -36,7 +38,9 @@ $now = $clock->now();
 Create a new frozen clock and use it in tests:
 
 ```php
-use Localheinz\Clock;
+<?php
+
+use Ergebnis\Clock;
 
 $now = new \DateTimeImmutable();
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "localheinz/clock",
+  "name": "ergebnis/clock",
   "type": "library",
   "description": "Provides a simple abstraction of a clock.",
   "keywords": [
@@ -7,7 +7,7 @@
     "system-clock",
     "test-clock"
   ],
-  "homepage": "https://github.com/localheinz/clock",
+  "homepage": "https://github.com/ergebnis/clock",
   "license": "MIT",
   "authors": [
     {
@@ -17,6 +17,9 @@
   ],
   "require": {
     "php": "^7.2"
+  },
+  "replace": {
+    "localheinz/clock": "*"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
@@ -36,16 +39,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\Clock\\": "src/"
+      "Ergebnis\\Clock\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\Clock\\Test\\": "test/"
+      "Ergebnis\\Clock\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/clock/issues",
-    "source": "https://github.com/localheinz/clock"
+    "issues": "https://github.com/ergebnis/clock/issues",
+    "source": "https://github.com/ergebnis/clock"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50280d61c3cc668be8cd473d0c169ac8",
+    "content-hash": "f6fd573210def7f8b33089d1a34325c8",
     "packages": [],
     "packages-dev": [
         {
@@ -1125,6 +1125,7 @@
                 "json",
                 "printer"
             ],
+            "abandoned": "ergebnis/json-printer",
             "time": "2018-08-11T23:54:50+00:00"
         },
         {

--- a/src/ClockInterface.php
+++ b/src/ClockInterface.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/clock
+ * @see https://github.com/ergebnis/clock
  */
 
-namespace Localheinz\Clock;
+namespace Ergebnis\Clock;
 
 interface ClockInterface
 {

--- a/src/FrozenClock.php
+++ b/src/FrozenClock.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/clock
+ * @see https://github.com/ergebnis/clock
  */
 
-namespace Localheinz\Clock;
+namespace Ergebnis\Clock;
 
 final class FrozenClock implements ClockInterface
 {

--- a/src/SystemClock.php
+++ b/src/SystemClock.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/clock
+ * @see https://github.com/ergebnis/clock
  */
 
-namespace Localheinz\Clock;
+namespace Ergebnis\Clock;
 
 final class SystemClock implements ClockInterface
 {

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/clock
+ * @see https://github.com/ergebnis/clock
  */
 
-namespace Localheinz\Clock\Test\AutoReview;
+namespace Ergebnis\Clock\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -34,8 +34,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\Clock\\',
-            'Localheinz\\Clock\\Test\\Unit\\'
+            'Ergebnis\\Clock\\',
+            'Ergebnis\\Clock\\Test\\Unit\\'
         );
     }
 }

--- a/test/Unit/FrozenClockTest.php
+++ b/test/Unit/FrozenClockTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/clock
+ * @see https://github.com/ergebnis/clock
  */
 
-namespace Localheinz\Clock\Test\Unit;
+namespace Ergebnis\Clock\Test\Unit;
 
+use Ergebnis\Clock\ClockInterface;
+use Ergebnis\Clock\FrozenClock;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Clock\ClockInterface;
-use Localheinz\Clock\FrozenClock;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Clock\FrozenClock
+ * @covers \Ergebnis\Clock\FrozenClock
  */
 final class FrozenClockTest extends Framework\TestCase
 {

--- a/test/Unit/SystemClockTest.php
+++ b/test/Unit/SystemClockTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/clock
+ * @see https://github.com/ergebnis/clock
  */
 
-namespace Localheinz\Clock\Test\Unit;
+namespace Ergebnis\Clock\Test\Unit;
 
+use Ergebnis\Clock\ClockInterface;
+use Ergebnis\Clock\SystemClock;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Clock\ClockInterface;
-use Localheinz\Clock\SystemClock;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Clock\SystemClock
+ * @covers \Ergebnis\Clock\SystemClock
  */
 final class SystemClockTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] renames the vendor namespace `Localheinz` to `Ergebnis` after the move to @ergebnis