### PR TITLE
Fix: Remove Interface suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ For a full diff see [`1.0.0...2.0.0`][1.0.0...2.0.0].
 
   to delete backup files created in the previous step.
 
+* Removed `Interface` suffix ([#53]), by [@localheinz]
+
 ### Fixed
 
 * Dropped support for PHP 7.1 ([#41]), by [@localheinz]
@@ -70,6 +72,7 @@ For a full diff see [`36912f6...1.0.0`][36912f6...1.0.0].
 [#2]: https://github.com/ergebnis/clock/pull/2
 [#41]: https://github.com/ergebnis/clock/pull/41
 [#52]: https://github.com/ergebnis/clock/pull/52
+[#53]: https://github.com/ergebnis/clock/pull/53
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/src/Clock.php
+++ b/src/Clock.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Clock;
 
-interface ClockInterface
+interface Clock
 {
     public function now(): \DateTimeImmutable;
 }

--- a/src/FrozenClock.php
+++ b/src/FrozenClock.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Clock;
 
-final class FrozenClock implements ClockInterface
+final class FrozenClock implements Clock
 {
     private $now;
 

--- a/src/SystemClock.php
+++ b/src/SystemClock.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Clock;
 
-final class SystemClock implements ClockInterface
+final class SystemClock implements Clock
 {
     private $timezone;
 

--- a/test/Unit/FrozenClockTest.php
+++ b/test/Unit/FrozenClockTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Clock\Test\Unit;
 
-use Ergebnis\Clock\ClockInterface;
+use Ergebnis\Clock\Clock;
 use Ergebnis\Clock\FrozenClock;
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,7 +29,7 @@ final class FrozenClockTest extends Framework\TestCase
 
     public function testImplementsClockInterface(): void
     {
-        self::assertClassImplementsInterface(ClockInterface::class, FrozenClock::class);
+        self::assertClassImplementsInterface(Clock::class, FrozenClock::class);
     }
 
     public function testNowReturnsInitializeDateTime(): void

--- a/test/Unit/SystemClockTest.php
+++ b/test/Unit/SystemClockTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Ergebnis\Clock\Test\Unit;
 
-use Ergebnis\Clock\ClockInterface;
+use Ergebnis\Clock\Clock;
 use Ergebnis\Clock\SystemClock;
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,7 +29,7 @@ final class SystemClockTest extends Framework\TestCase
 
     public function testImplementsClockInterface(): void
     {
-        self::assertClassImplementsInterface(ClockInterface::class, SystemClock::class);
+        self::assertClassImplementsInterface(Clock::class, SystemClock::class);
     }
 
     public function testNowReturnsCurrentDateTime(): void


### PR DESCRIPTION
This PR

* [x] removes the `Interface` suffix