### PR TITLE
Fix: Support for PHP 7.0 has been dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,4 @@ This package is licensed using the MIT License.
 ## Credits
 
 This project is inspired by [`lcobucci/clock`](https://github.com/lcobucci/clock)
-(originally licensed under MIT by [Luís Cobucci](https://github.com/lcobucci)),
-with additional support for PHP 7.0.
+(originally licensed under MIT by [Luís Cobucci](https://github.com/lcobucci)).


### PR DESCRIPTION
This PR

* [x] removes a note saying that this project supports PHP 7.0