### PR TITLE
Fix: Remove inappropriate replace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.0.0...master`][2.0.0...master].
+For a full diff see [`2.0.1...master`][2.0.1...master].
+
+## [`2.0.1`][2.0.1]
+
+For a full diff see [`2.0.0...2.0.1`][2.0.0...2.0.1].
+
+### Fixed
+
+* Removed an inappropriate `replace` configuration from `composer.json` ([#57]), by [@localheinz]
 
 ## [`2.0.0`][2.0.0]
 
@@ -63,16 +71,19 @@ For a full diff see [`36912f6...1.0.0`][36912f6...1.0.0].
 
 [1.0.0]: https://github.com/ergebnis/clock/releases/tag/1.0.0
 [2.0.0]: https://github.com/ergebnis/clock/releases/tag/2.0.0
+[2.0.1]: https://github.com/ergebnis/clock/releases/tag/2.0.1
 
 [36912f6...1.0.0]: https://github.com/ergebnis/clock/compare/36912f6...1.0.0
 [1.0.0...2.0.0]: https://github.com/ergebnis/clock/compare/1.0.0...2.0.0
-[2.0.0...master]: https://github.com/ergebnis/clock/compare/2.0.0...master
+[2.0.0...2.0.1]: https://github.com/ergebnis/clock/compare/2.0.0...2.0.1
+[2.0.1...master]: https://github.com/ergebnis/clock/compare/2.0.1...master
 
 [#1]: https://github.com/ergebnis/clock/pull/1
 [#2]: https://github.com/ergebnis/clock/pull/2
 [#41]: https://github.com/ergebnis/clock/pull/41
 [#52]: https://github.com/ergebnis/clock/pull/52
 [#53]: https://github.com/ergebnis/clock/pull/53
+[#57]: https://github.com/ergebnis/clock/pull/57
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,6 @@
   "require": {
     "php": "^7.2"
   },
-  "replace": {
-    "localheinz/clock": "*"
-  },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
     "ergebnis/phpstan-rules": "~0.14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89a9ecce5bf0d003e4e6dadcd6fc55fe",
+    "content-hash": "628283746f3be1cdc6cf32fa0b6cf465",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
This PR

* [x] removes an inappropriate `replace` configuration from `composer.json`

Follows #52.