### PR TITLE
Fix: Rename `.php_cs` to `.php-cs-fixer.php`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,7 @@
 /.editorconfig                  export-ignore
 /.gitattributes                 export-ignore
 /.gitignore                     export-ignore
-/.php_cs                        export-ignore
+/.php-cs-fixer.php              export-ignore
 /composer-require-checker.json  export-ignore
 /infection.json                 export-ignore
 /Makefile                       export-ignore

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -77,7 +77,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-php-cs-fixer-"
 
       - name: "Run friendsofphp/php-cs-fixer"
-        run: "vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --dry-run --verbose"
+        run: "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --diff-format=udiff --dry-run --verbose"
 
   dependency-analysis:
     name: "Dependency Analysis"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -65,7 +65,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-php-cs-fixer-"
 
       - name: "Run friendsofphp/php-cs-fixer"
-        run: "vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --verbose"
+        run: "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --diff-format=udiff --verbose"
 
       - name: "Commit modified files"
         uses: "stefanzweifel/git-auto-commit-action@v4.12.0"

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -36,8 +36,8 @@ $config->getFinder()
     ])
     ->ignoreDotFiles(false)
     ->in(__DIR__)
-    ->name('.php_cs');
+    ->name('.php-cs-fixer.php');
 
-$config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php_cs.cache');
+$config->setCacheFile(__DIR__ . '/.build/php-cs-fixer/.php-cs-fixer.cache');
 
 return $config;

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ coding-standards: vendor ## Normalizes composer.json with ergebnis/composer-norm
 	composer normalize
 	yamllint -c .yamllint.yaml --strict .
 	mkdir -p .build/php-cs-fixer
-	vendor/bin/php-cs-fixer fix --config=.php_cs --diff --diff-format=udiff --verbose
+	vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --diff-format=udiff --verbose
 
 .PHONY: dependency-analysis
 dependency-analysis: vendor ## Runs a dependency analysis with maglnet/composer-require-checker


### PR DESCRIPTION
This pull request

* [x] renames `.php_cs` to `.php-cs-fixer.php`