### PR TITLE
Implement forward compatible Clock-Interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require": {
     "php": "^7.4 || ^8.0",
-    "stella-maris/clock": "^0.1.1"
+    "stella-maris/clock": "^0.1.3"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.25.1",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require": {
     "php": "^7.4 || ^8.0",
-    "stella-maris/clock": "^0.1.3"
+    "stella-maris/clock": "^0.1.4"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.25.1",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "source": "https://github.com/ergebnis/clock"
   },
   "require": {
-    "php": "^7.4 || ^8.0"
+    "php": "^7.4 || ^8.0",
+    "stella-maris/clock": "^0.1.1"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.25.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "368fa9a4c647b6c1c3c1bbafc479bdd5",
+    "content-hash": "0fe2eec0def406a3e03cb812e9089f1c",
     "packages": [
         {
             "name": "stella-maris/clock",
-            "version": "0.1.3",
+            "version": "0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://gitlab.com/stella-maris/clock.git",
-                "reference": "21a9b527a9329015632ac9ff2466bfa1630fc795"
+                "reference": "8a0a967896df4c63417385dc69328a0aec84d9cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/stella-maris%2Fclock/repository/archive.zip?sha=21a9b527a9329015632ac9ff2466bfa1630fc795",
-                "reference": "21a9b527a9329015632ac9ff2466bfa1630fc795",
+                "url": "https://gitlab.com/api/v4/projects/stella-maris%2Fclock/repository/archive.zip?sha=8a0a967896df4c63417385dc69328a0aec84d9cf",
+                "reference": "8a0a967896df4c63417385dc69328a0aec84d9cf",
                 "shasum": ""
             },
             "require": {
@@ -25,9 +25,6 @@
             },
             "type": "library",
             "autoload": {
-                "files": [
-                    "polyfill-psr20.php"
-                ],
                 "psr-4": {
                     "StellaMaris\\Clock\\": "src"
                 }
@@ -52,9 +49,9 @@
             ],
             "support": {
                 "issues": "https://gitlab.com/stella-maris/clock/-/issues",
-                "source": "https://gitlab.com/stella-maris/clock/-/tree/0.1.3"
+                "source": "https://gitlab.com/stella-maris/clock/-/tree/0.1.4"
             },
-            "time": "2022-04-17T12:41:28+00:00"
+            "time": "2022-04-17T14:12:26+00:00"
         }
     ],
     "packages-dev": [
@@ -6115,5 +6112,5 @@
     "platform-overrides": {
         "php": "7.4.25"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,51 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f467021a080e2feb976ce43c9e3b35a6",
-    "packages": [],
+    "content-hash": "368fa9a4c647b6c1c3c1bbafc479bdd5",
+    "packages": [
+        {
+            "name": "stella-maris/clock",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://gitlab.com/stella-maris/clock.git",
+                "reference": "ba19b9fd3d8926c4e4e2a494206b56e662573c90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://gitlab.com/api/v4/projects/stella-maris%2Fclock/repository/archive.zip?sha=ba19b9fd3d8926c4e4e2a494206b56e662573c90",
+                "reference": "ba19b9fd3d8926c4e4e2a494206b56e662573c90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0|^8.0"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Heigl",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "A pre-release of the proposed PSR-20 Clock-Interface",
+            "homepage": "https://gitlab.com/stella-maris/clock",
+            "keywords": [
+                "clock",
+                "datetime",
+                "point in time",
+                "psr20"
+            ],
+            "support": {
+                "issues": "https://gitlab.com/stella-maris/clock/-/issues",
+                "source": "https://gitlab.com/stella-maris/clock/-/tree/0.1.1"
+            },
+            "time": "2022-04-17T11:36:51+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "amphp/amp",

--- a/composer.lock
+++ b/composer.lock
@@ -8,22 +8,30 @@
     "packages": [
         {
             "name": "stella-maris/clock",
-            "version": "0.1.1",
+            "version": "0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://gitlab.com/stella-maris/clock.git",
-                "reference": "ba19b9fd3d8926c4e4e2a494206b56e662573c90"
+                "reference": "21a9b527a9329015632ac9ff2466bfa1630fc795"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/stella-maris%2Fclock/repository/archive.zip?sha=ba19b9fd3d8926c4e4e2a494206b56e662573c90",
-                "reference": "ba19b9fd3d8926c4e4e2a494206b56e662573c90",
+                "url": "https://gitlab.com/api/v4/projects/stella-maris%2Fclock/repository/archive.zip?sha=21a9b527a9329015632ac9ff2466bfa1630fc795",
+                "reference": "21a9b527a9329015632ac9ff2466bfa1630fc795",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0|^8.0"
             },
             "type": "library",
+            "autoload": {
+                "files": [
+                    "polyfill-psr20.php"
+                ],
+                "psr-4": {
+                    "StellaMaris\\Clock\\": "src"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -44,9 +52,9 @@
             ],
             "support": {
                 "issues": "https://gitlab.com/stella-maris/clock/-/issues",
-                "source": "https://gitlab.com/stella-maris/clock/-/tree/0.1.1"
+                "source": "https://gitlab.com/stella-maris/clock/-/tree/0.1.3"
             },
-            "time": "2022-04-17T11:36:51+00:00"
+            "time": "2022-04-17T12:41:28+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Clock.php
+++ b/src/Clock.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Ergebnis\Clock;
 
-interface Clock
+use StellaMaris\Clock\ClockInterface;
+
+interface Clock extends ClockInterface
 {
     public function now(): \DateTimeImmutable;
 }


### PR DESCRIPTION
The [`stella-maris/clock`](https://gitlab.com/stella-maris/clock) package provides an interface based on the currently proposed status of PSR20. Due to the inactivity of the PSR20 working group this is a way to already provide interoperability while still maintaining forward compatibility. When the current status of PSR20 will be released at one point in time the stella-maris/clock package will extend the PSR20 interface so that this package becomes immeadiately PSR20 compatible without any further work necessary. In the long run the stella-maris/clock package will then be marked deprecated so that people can then use the PSR20 provided implementation.

Should the implementation of PSR20 change between now and a possible release then this interface will still exist and a possible implementation will need more code-changes anyhow so this interface will still provide some way of interoperability.