### PR TITLE
Fix: Allow `composer` plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,10 @@
     }
   },
   "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true,
+      "infection/extension-installer": true
+    },
     "platform": {
       "php": "7.4.25"
     },


### PR DESCRIPTION
This pull request

- [x] allows `composer` plugins to run